### PR TITLE
include type name

### DIFF
--- a/terra_bonobo_nodes/elasticsearch.py
+++ b/terra_bonobo_nodes/elasticsearch.py
@@ -142,7 +142,8 @@ class ESGeometryField(Configurable):
                             'tree': 'quadtree',
                             }
                     },
-                }
+                },
+                include_type_name=True,
             )
             indice.put_settings(
                 index=self.index,


### PR DESCRIPTION
Related to https://github.com/Terralego/visu-back/pull/36

Fixing this error after upgrading es6 to es7:
```bash
elasticsearch.exceptions.RequestError  RequestError(400, 'illegal_argument_exception', 'Types cannot be provided in put mapping requests, unless the include_type_name parameter is set to true.')
```